### PR TITLE
Faster __new__/from_gdal

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -171,8 +171,11 @@ class Affine(
         a, b, c, d, e, f : float
             Elements of an augmented affine transformation matrix.
         """
-        mat3x3 = [x * 1.0 for x in [a, b, c, d, e, f]] + [0.0, 0.0, 1.0]
-        return tuple.__new__(cls, mat3x3)
+        return tuple.__new__(
+            cls,
+            (a * 1.0, b * 1.0, c * 1.0,
+             d * 1.0, e * 1.0, f * 1.0,
+             0.0,     0.0,     1.0))
 
     @classmethod
     def from_gdal(cls, c, a, b, f, d, e):
@@ -181,9 +184,7 @@ class Affine(
         :param c, a, b, f, d, e: 6 floats ordered by GDAL.
         :rtype: Affine
         """
-        members = [a, b, c, d, e, f]
-        mat3x3 = [x * 1.0 for x in members] + [0.0, 0.0, 1.0]
-        return tuple.__new__(cls, mat3x3)
+        return cls.__new__(cls, a, b, c, d, e, f)
 
     @classmethod
     def identity(cls):


### PR DESCRIPTION
A faster implementation of Affine.__new__.

%timeit Affine(3, 2, 5, 1, 2, 3)
1.21 µs ± 48.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
vs.
%timeit Affine(3, 2, 5, 1, 2, 3)
727 ns ± 30.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

Similar speedup in Affine.from_gdal
%timeit Affine.from_gdal(3, 2, 5, 1, 2, 3)
1.16 µs ± 11 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
vs
%timeit Affine.from_gdal(3, 2, 5, 1, 2, 3)
784 ns ± 9.34 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)