### PR TITLE
Add required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     url="https://github.com/sgillies/affine",
     license="BSD",
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
+    python_requires='>=3.6',
     include_package_data=True,
     zip_safe=True,
     extras_require={


### PR DESCRIPTION
The lowest python version with test is python 3.6. So define this as minimum required version.

Closes #49