### PR TITLE
Require Python >=3.7, minor pyupgrade changes

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -608,7 +608,7 @@ def loadsw(s: str):
     coeffs = s.split()
     if len(coeffs) != 6:
         raise ValueError("Expected 6 coefficients, found %d" % len(coeffs))
-    a, d, b, e, c, f = [float(x) for x in coeffs]
+    a, d, b, e, c, f = (float(x) for x in coeffs)
     center = tuple.__new__(Affine, [a, b, c, d, e, f, 0.0, 0.0, 1.0])
     return center * Affine.translation(-0.5, -0.5)
 

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -39,9 +39,9 @@ from affine import Affine, EPSILON
 
 
 def seq_almost_equal(t1, t2, error=0.00001):
-    assert len(t1) == len(t2), "%r != %r" % (t1, t2)
+    assert len(t1) == len(t2), f"{t1!r} != {t2!r}"
     for m1, m2 in zip(t1, t2):
-        assert abs(m1 - m2) <= error, "%r != %r" % (t1, t2)
+        assert abs(m1 - m2) <= error, f"{t1!r} != {t2!r}"
 
 
 class PyAffineTestCase(unittest.TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Multimedia :: Graphics :: Graphics Conversion",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-license = {text = "BSD"}
+license = {text = "BSD-3-Clause"}
+requires-python = ">=3.7"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Affine [2.4b1](https://pypi.org/project/affine/2.4b1/) can be installed in Python 2, since the file `affine-2.4b1-py2.py3-none-any.whl` implies py2 compatibility, but does not "run" after installed:
```
$ python2 -c "import affine"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/py27/lib/python2.7/site-packages/affine/__init__.py", line 44
    EPSILON: float = 1e-5
           ^
SyntaxError: invalid syntax
```
this PR limits it to Python 3.7, which is the minimum version tested in CI. There are no technical limitations why affine wouldn't work with earlier Python 3 releases, but there is no guarantee.

Two other minor changes:

- Apply a few changes suggested by [pyupgrade](https://github.com/asottile/pyupgrade/) with `--py37-plus`
- Use SPDX licence identifier [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)