### PR TITLE
Add Affine.to_cairo, to output data in column major order suitable for cairo.Matrix(...)

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -299,6 +299,15 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         """
         return (self.c, self.a, self.b, self.f, self.d, self.e)
 
+    def to_cairo(self):
+        """Return a transformation matrix compatible with PyCairo.
+
+        >>> cairo.Matrix(*affine.to_cairo())
+
+        :rtype: tuple
+        """
+        return (self.a, self.d, self.b, self.e, self.c, self.f)
+
     def to_shapely(self):
         """Return an affine transformation matrix compatible with shapely
 
@@ -341,10 +350,10 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         # The singular values are the square root of the eigenvalues
         # of the matrix times its transpose, M M*
         # Computing trace and determinant of M M*
-        trace = a ** 2 + b ** 2 + d ** 2 + e ** 2
+        trace = a**2 + b**2 + d**2 + e**2
         det = (a * e - b * d) ** 2
 
-        delta = trace ** 2 / 4 - det
+        delta = trace**2 / 4 - det
         if delta < 1e-12:
             delta = 0
 
@@ -362,7 +371,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         Raises NotImplementedError for improper transformations.
         """
         l1, l2 = self._scaling
-        return math.sqrt(l1 ** 2 - l2 ** 2) / l1
+        return math.sqrt(l1**2 - l2**2) / l1
 
     @property
     def rotation_angle(self) -> float:


### PR DESCRIPTION
Trying to use Affine with cairo really confused, me until I found the comment in the cairo code, which made me wonder if there was a difference in the order -

https://gitlab.freedesktop.org/cairo/cairo/-/blob/master/src/cairo-matrix.c#L318

This probably needs a from_cairo, docs, and maybe some tests with round-trips.

The tests should probably be skipped if pycairo is not installed.