### PR TITLE
Add pre-commit with ruff, and other checks (EOL, trailing whitespace)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,20 @@ env:
   LATEST_PY_VERSION: '3.11'
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: 3.*
+      - name: pre-commit checks
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --all-files
+
   tests:
     runs-on: ubuntu-latest
     strategy:
@@ -41,42 +55,3 @@ jobs:
           files: ./coverage.xml
           flags: unittests
           fail_ci_if_error: false
-
-  lint:
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install flake8 pydocstyle
-
-      - name: Run lint
-        run: |
-          flake8 --ignore=E501,W503
-          python -m pydocstyle affine
-
-  typing:
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install mypy pytest
-
-      - name: Run typing test
-        run: |
-          mypy affine

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+ci:
+  autoupdate_schedule: quarterly
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,7 +63,7 @@ Bug fixes:
 
 2.0b2 (2016-05-16)
 ------------------
-- Bug fix: restore ``Affine __rmul__`` even though it permits dubious 
+- Bug fix: restore ``Affine __rmul__`` even though it permits dubious
   vector * matrix expressions (#27).
 
 2.0b1 (2016-05-16)

--- a/README.rst
+++ b/README.rst
@@ -98,4 +98,3 @@ The reverse transformation is obtained using the ``~`` operator.
   >>> rev = ~fwd
   >>> rev * fwd * (col, row)
   (0.0, 99.99999999999999)
-

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -341,10 +341,10 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         # The singular values are the square root of the eigenvalues
         # of the matrix times its transpose, M M*
         # Computing trace and determinant of M M*
-        trace = a ** 2 + b ** 2 + d ** 2 + e ** 2
+        trace = a**2 + b**2 + d**2 + e**2
         det = (a * e - b * d) ** 2
 
-        delta = trace ** 2 / 4 - det
+        delta = trace**2 / 4 - det
         if delta < 1e-12:
             delta = 0
 
@@ -362,7 +362,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         Raises NotImplementedError for improper transformations.
         """
         l1, l2 = self._scaling
-        return math.sqrt(l1 ** 2 - l2 ** 2) / l1
+        return math.sqrt(l1**2 - l2**2) / l1
 
     @property
     def rotation_angle(self) -> float:

--- a/affine/tests/test_pickle.py
+++ b/affine/tests/test_pickle.py
@@ -2,7 +2,6 @@
 Validate that instances of `affine.Affine()` can be pickled and unpickled.
 """
 
-
 import pickle
 from multiprocessing import Pool
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -6,45 +6,45 @@ import os
 
 import sys
 
-sys.path.append(os.path.abspath('../..'))
+sys.path.append(os.path.abspath("../.."))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'rasterio/affine'
-copyright = '2023, Sean Gillies'
-author = 'Sean Gillies'
-release = 'development'
+project = "rasterio/affine"
+copyright = "2023, Sean Gillies"
+author = "Sean Gillies"
+release = "development"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.coverage',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["Thumbs.db", ".DS_Store"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The root toctree document.
-root_doc = 'index'
+root_doc = "index"
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'nature'
+html_theme = "nature"
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # If this is not None, a ‘Last updated on:’ timestamp is inserted at every page bottom.
-html_last_updated_fmt = ''
+html_last_updated_fmt = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ test = [
     "pytest-cov",
 ]
 dev = [
-    "pydocstyle",
-    "flake8",
     "coveralls",
 ]
 
@@ -42,3 +40,17 @@ include = [
     "CHANGES.txt",
     "LICENSE.txt",
 ]
+
+[tool.ruff.lint]
+select = [
+    "D1",  # pydocstyle
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+]
+ignore = [
+    "D105",  # Missing docstring in magic method
+]
+
+[tool.ruff.lint.per-file-ignores]
+"affine/tests/**.py" = ["D"]
+"docs/**.py" = ["D"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[tool:pytest]
-testpaths: affine/tests
-
-[pydocstyle]
-select: D1
-add-ignore: D105


### PR DESCRIPTION
This adds a pre-commit configuration that migrates a few tools:

- Add check-yaml, end-of-file-fixer and trailing-whitespace with a few expected changes
- Add Ruff linter and formatter, which has a few minor changes to the main source code
- Migrate pydocstyle and flake8 (pycodestyle, pyflakes) configuration to Ruff linter
- Remove `setup.cfg`, as the configuration is moved and pytest doesn't need any
- Remove CI jobs "lint" and "typing" 
- Add a CI job "pre-commit" to run; however I highly recommend https://pre-commit.ci to be configured for this repo instead
- the "dev" optional install list is nearly empty, and I think it could be removed (not done here yet)