### PR TITLE
Subtle misc. refactors and lint suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           pre-commit run --show-diff-on-failure --all-files
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.8.3
     hooks:
       # Run the linter.
       - id: ruff
@@ -16,6 +16,6 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.13.0
     hooks:
       - id: mypy

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -32,9 +32,9 @@ copyright statement below.
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #############################################################################
 
+from collections import namedtuple
 import math
 import warnings
-from collections import namedtuple
 
 __all__ = ["Affine"]
 __author__ = "Sean Gillies"

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -592,7 +592,7 @@ def loadsw(s: str):
         raise TypeError("Cannot split input string")
     coeffs = s.split()
     if len(coeffs) != 6:
-        raise ValueError("Expected 6 coefficients, found %d" % len(coeffs))
+        raise ValueError(f"Expected 6 coefficients, found {len(coeffs)}")
     a, d, b, e, c, f = (float(x) for x in coeffs)
     center = tuple.__new__(Affine, [a, b, c, d, e, f, 0.0, 0.0, 1.0])
     return center * Affine.translation(-0.5, -0.5)

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -1,4 +1,4 @@
-"""Affine transformation matrices.
+"""Affine transformation matrices
 
 The Affine package is derived from Casey Duncan's Planar package. See the
 copyright statement below.
@@ -48,18 +48,17 @@ class AffineError(Exception):
 
 
 class TransformNotInvertibleError(AffineError):
-    """The transform could not be inverted."""
+    """The transform could not be inverted"""
 
 
 class UndefinedRotationError(AffineError):
-    """The rotation angle could not be computed for this transform."""
+    """The rotation angle could not be computed for this transform"""
 
 
 def cached_property(func):
-    """Cached property decorator.
-
-    This special property decorator caches the computed property value in the
-    object's instance dict the first time it is accessed.
+    """Special property decorator that caches the computed
+    property value in the object's instance dict the first
+    time it is accessed.
     """
     name = func.__name__
     doc = func.__doc__
@@ -107,7 +106,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         `a`, `b`, and `c` are the elements of the first row of the
         matrix. `d`, `e`, and `f` are the elements of the second row.
 
-    Attributes:
+    Attributes
     ----------
     a, b, c, d, e, f, g, h, i : float
         The coefficients of the 3x3 augmented affine transformation
@@ -154,12 +153,13 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         h: float = 0.0,
         i: float = 1.0,
     ):
-        """Create a new object.
+        """Create a new object
 
         Parameters
         ----------
         a, b, c, d, e, f : float
             Elements of an augmented affine transformation matrix.
+
         """
         return tuple.__new__(
             cls,
@@ -256,7 +256,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
 
     @classmethod
     def permutation(cls, *scaling):
-        """Create the permutation transform.
+        """Create the permutation transform
 
         For 2x2 matrices, there is only one permutation matrix that is
         not the identity.
@@ -289,7 +289,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         return (self.c, self.a, self.b, self.f, self.d, self.e)
 
     def to_shapely(self):
-        """Return an affine transformation matrix compatible with shapely.
+        """Return an affine transformation matrix compatible with shapely
 
         Shapely's affinity module expects an affine transformation matrix
         in (a,b,d,e,xoff,yoff) order.
@@ -300,12 +300,12 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
 
     @property
     def xoff(self) -> float:
-        """Alias for 'c'."""
+        """Alias for 'c'"""
         return self.c
 
     @property
     def yoff(self) -> float:
-        """Alias for 'f'."""
+        """Alias for 'f'"""
         return self.f
 
     @cached_property
@@ -374,7 +374,9 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
 
     @property
     def is_identity(self) -> bool:
-        """True if this transform equals the identity matrix, within rounding limits."""
+        """True if this transform equals the identity matrix,
+        within rounding limits.
+        """
         return self is identity or self.almost_equals(identity, self.precision)
 
     @property
@@ -436,7 +438,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
 
     @property
     def column_vectors(self):
-        """The values of the transform as three 2D column vectors."""
+        """The values of the transform as three 2D column vectors"""
         a, b, c, d, e, f, _, _, _ = self
         return (a, d), (b, e), (c, f)
 
@@ -468,7 +470,7 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
     __iadd__ = __add__
 
     def __mul__(self, other):
-        """Multiplication.
+        """Multiplication
 
         Apply the transform using matrix multiplication, creating
         a resulting object of the same type.  A transform may be applied
@@ -504,17 +506,18 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
                 return NotImplemented
 
     def __rmul__(self, other):
-        """Right hand multiplication.
+        """Right hand multiplication
 
         .. deprecated:: 2.3.0
             Right multiplication will be prohibited in version 3.0. This method
             will raise AffineError.
 
-        Notes:
+        Notes
         -----
         We should not be called if other is an affine instance This is
         just a guarantee, since we would potentially return the wrong
         answer in that case.
+
         """
         warnings.warn(
             "Right multiplication will be prohibited in version 3.0",
@@ -564,13 +567,14 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
     __hash__ = tuple.__hash__  # hash is not inherited in Py 3
 
     def __getnewargs__(self):
-        """Pickle protocol support.
+        """Pickle protocol support
 
-        Notes:
+        Notes
         -----
         Normal unpickling creates a situation where __new__ receives all
         9 elements rather than the 6 that are required for the
         constructor.  This method ensures that only the 6 are provided.
+
         """
         return self.a, self.b, self.c, self.d, self.e, self.f
 

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -245,12 +245,14 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
             return tuple.__new__(cls, (ca, -sa, 0.0, sa, ca, 0.0, 0.0, 0.0, 1.0))
         else:
             px, py = pivot
-            c = px - px * ca + py * sa
-            f = py - px * sa - py * ca
+            # fmt: off
             return tuple.__new__(
                 cls,
-                (ca, -sa, c, sa, ca, f, 0.0, 0.0, 1.0),
+                (ca, -sa, px - px * ca + py * sa,
+                 sa, ca, py - px * sa - py * ca,
+                 0.0, 0.0, 1.0),
             )
+            # fmt: on
 
     @classmethod
     def permutation(cls, *scaling):

--- a/affine/tests/test_pickle.py
+++ b/affine/tests/test_pickle.py
@@ -2,8 +2,8 @@
 Validate that instances of `affine.Affine()` can be pickled and unpickled.
 """
 
-import pickle
 from multiprocessing import Pool
+import pickle
 
 import affine
 

--- a/affine/tests/test_rotation.py
+++ b/affine/tests/test_rotation.py
@@ -1,5 +1,7 @@
 import math
 
+import pytest
+
 from affine import Affine
 
 
@@ -23,8 +25,9 @@ def test_rotation_angle():
         0----------
     """
     x, y = Affine.rotation(45.0) * (1.0, 0.0)
-    assert round(x, 14) == round(math.sqrt(2.0) / 2.0, 14)
-    assert round(y, 14) == round(math.sqrt(2.0) / 2.0, 14)
+    sqrt2div2 = math.sqrt(2.0) / 2.0
+    assert x == pytest.approx(sqrt2div2)
+    assert y == pytest.approx(sqrt2div2)
 
 
 def test_rotation_matrix():
@@ -34,12 +37,16 @@ def test_rotation_matrix():
     | sin(a)  cos(a) |
 
     """
-    rot = Affine.rotation(90.0)
-    assert round(rot.a, 15) == round(math.cos(math.pi / 2.0), 15)
-    assert round(rot.b, 15) == round(-math.sin(math.pi / 2.0), 15)
+    deg = 90.0
+    rot = Affine.rotation(deg)
+    rad = math.radians(deg)
+    cosrad = math.cos(rad)
+    sinrad = math.sin(rad)
+    assert rot.a == pytest.approx(cosrad)
+    assert rot.b == pytest.approx(-sinrad)
     assert rot.c == 0.0
-    assert round(rot.d, 15) == round(math.sin(math.pi / 2.0), 15)
-    assert round(rot.e, 15) == round(math.cos(math.pi / 2.0), 15)
+    assert rot.d == pytest.approx(sinrad)
+    assert rot.e == pytest.approx(cosrad)
     assert rot.f == 0.0
 
 
@@ -52,4 +59,4 @@ def test_rotation_matrix_pivot():
         * Affine.translation(-1.0, -1.0)
     )
     for r, e in zip(rot, exp):
-        assert round(r, 15) == round(e, 15)
+        assert r == pytest.approx(e)

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -29,8 +29,8 @@
 """Transform unit tests"""
 
 import math
-import unittest
 from textwrap import dedent
+import unittest
 
 import pytest
 

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -35,7 +35,7 @@ from textwrap import dedent
 import pytest
 
 import affine
-from affine import Affine, EPSILON
+from affine import EPSILON, Affine
 
 
 def seq_almost_equal(t1, t2, error=0.00001):
@@ -369,7 +369,7 @@ class PyAffineTestCase(unittest.TestCase):
 
     def test_bad_value_world(self):
         """Wrong number of parameters."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Expected 6 coefficients"):
             affine.loadsw("1.0\n0.0\n0.0\n1.0\n0.0\n0.0\n0.0")
 
     def test_simple_world(self):

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -3,7 +3,6 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
-
 import sys
 
 sys.path.append(os.path.abspath("../.."))
@@ -46,5 +45,5 @@ html_theme = "nature"
 
 html_static_path = ["_static"]
 
-# If this is not None, a ‘Last updated on:’ timestamp is inserted at every page bottom.
+# If this is not None, a 'Last updated on:' timestamp is inserted at every page bottom.
 html_last_updated_fmt = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,8 @@ ignore = [
 "affine/tests/**.py" = ["B", "D"]
 "docs/**.py" = ["D"]
 
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ include = [
 [tool.ruff.lint]
 select = [
     "B",  # flake8-bugbear
-    "D",  # pydocstyle
+    "D1",  # pydocstyle
     "E", "W",  # pycodestyle
     "F",  # Pyflakes
     "I",  # isort
@@ -62,6 +62,3 @@ ignore = [
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,22 @@ include = [
 
 [tool.ruff.lint]
 select = [
-    "D1",  # pydocstyle
-    "E",  # pycodestyle
+    "B",  # flake8-bugbear
+    "D",  # pydocstyle
+    "E", "W",  # pycodestyle
     "F",  # Pyflakes
+    "I",  # isort
+    "PT", # flake8-pytest-style
+    "RUF", # Ruff-specific rules
+    "UP", # pyupgrade
 ]
 ignore = [
     "D105",  # Missing docstring in magic method
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"affine/tests/**.py" = ["D"]
+"affine/tests/**.py" = ["B", "D"]
 "docs/**.py" = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"


### PR DESCRIPTION
This PR has several miscellaneous refactors and applied lint suggestions via `ruff check` rules:

- <s>Apply pydocstyle rules with "google" convention; these changes were mostly automated with a few manual edits for line lengths</s>
- Apply isort (I) rule
- Apply pyupgrade (UP) rule, which uses `format()` instead of `%` formats
- Better use of `pytest.approx()` rather than `assert round(...` expressions

The only subtle change in this PR that is arguably not a refactor is to `__new__`, which will enforce `float` types. For instance, before this was the behavior:
```pycon
>>> import numpy as np
>>> from affine import Affine
>>> Affine(*np.arange(6, dtype=np.float32))
Affine(np.float32(0.0), np.float32(1.0), np.float32(2.0),
       np.float32(3.0), np.float32(4.0), np.float32(5.0))
```
now with this PR the properties are all Python-native `float` types.
```pycon
>>> Affine(*np.arange(6, dtype=np.float32))
Affine(0.0, 1.0, 2.0,
       3.0, 4.0, 5.0)
```