### PR TITLE
Add numpy `__array__` interface

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -265,6 +265,39 @@ class Affine(namedtuple("Affine", ("a", "b", "c", "d", "e", "f", "g", "h", "i"))
         """
         return tuple.__new__(cls, (0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0))
 
+    def __array__(self, dtype=None, copy=None):
+        """Return a 3x3 NumPy array.
+
+        Parameters
+        ----------
+        dtype : data-type, optional
+            The desired data-type for the array.
+        copy : bool, optional
+            If None (default) or True, a copy of the array is always returned.
+            If False, a ValueError is raised as this is not supported.
+
+        Returns
+        -------
+        array
+
+        Raises
+        ------
+        ValueError
+            If ``copy=False`` is specified.
+        """
+        import numpy as np
+
+        if copy is False:
+            raise ValueError("`copy=False` isn't supported. A copy is always created.")
+        return np.array(
+            [
+                [self.a, self.b, self.c],
+                [self.d, self.e, self.f],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=dtype or float,
+        )
+
     def __str__(self) -> str:
         """Concise string representation."""
         return (

--- a/affine/tests/test_numpy.py
+++ b/affine/tests/test_numpy.py
@@ -1,0 +1,42 @@
+"""Test interoperability with NumPy."""
+
+import pytest
+
+from affine import Affine
+
+try:
+    import numpy as np
+    from numpy import testing
+except ImportError:
+    pytest.skip("requires numpy", allow_module_level=True)
+
+
+def test_array():
+    tfm = Affine(*np.linspace(0.1, 0.6, 6))
+    tfm_ar = np.array(tfm)
+    expected = np.array(
+        [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+            [0.0, 0.0, 1.0],
+        ],
+    )
+    assert tfm_ar.shape == (3, 3)
+    assert tfm_ar.dtype == np.float64
+    testing.assert_allclose(tfm_ar, expected)
+
+    # dtype option
+    tfm_ar = np.array(tfm, dtype=np.float32)
+    assert tfm_ar.shape == (3, 3)
+    assert tfm_ar.dtype == np.float32
+    testing.assert_allclose(tfm_ar, expected)
+
+    # copy option
+    tfm_ar = np.array(tfm, copy=True)  # default None does the same
+
+    # Behaviour of copy=False is different between NumPy 1.x and 2.x
+    if int(np.version.short_version.split(".", 1)[0]) >= 2:
+        with pytest.raises(ValueError, match="A copy is always created"):
+            np.array(tfm, copy=False)
+    else:
+        testing.assert_allclose(np.array(tfm, copy=False), expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 test = [
+    "numpy",
     "pytest >=4.6",
     "pytest-cov",
 ]
@@ -48,6 +49,7 @@ select = [
     "E", "W",  # pycodestyle
     "F",  # Pyflakes
     "I",  # isort
+    "NPY", # NumPy-specific rules
     "PT", # flake8-pytest-style
     "RUF", # Ruff-specific rules
     "UP", # pyupgrade


### PR DESCRIPTION
This adds a basic `__array__` interface using the latest [numpy docs](https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array__). It does not require a numpy dependency.

Before this PR, attempting to create a NumPy array would only make a 1D array with 9 items:
```pycon
>>> import numpy as np
>>> from affine import Affine
>>> tfm = Affine(*np.linspace(0.1, 0.6, 6))
>>> tfm
Affine(0.1, 0.2, 0.30000000000000004,
       0.4, 0.5, 0.6)
>>> np.array(tfm)
array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0. , 0. , 1. ])
```
now with this PR it is a 3x3 array as should be expected:
```pycon
>>> np.array(tfm)
array([[0.1, 0.2, 0.3],
       [0.4, 0.5, 0.6],
       [0. , 0. , 1. ]])
```