### PR TITLE
Base Affine on attrs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,4 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
+        additional_dependencies: [attrs]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ CHANGES
 3.0a1 (2024-12-27)
 ------------------
 
+- Switch from namedtuple to attrs for implementation of the Affine class and
+  use functools.cached_property(), which absolutely requires Python 3.8+
+  (#111).
 - Source was moved to src/ and Python version support was changed to 3.9+
   (#110).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
 ]
 license = {text = "BSD-3-Clause"}
 requires-python = ">=3.9"
+dependencies = [
+    "attrs",
+]
 
 [project.optional-dependencies]
 test = [

--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -34,6 +34,7 @@ copyright statement below.
 
 from functools import cached_property
 import math
+from typing import Optional
 import warnings
 
 from attrs import astuple, define, field
@@ -501,7 +502,7 @@ class Affine:
         """
         return (self.a, self.d), (self.b, self.e), (self.c, self.f)
 
-    def almost_equals(self, other, precision: float = None) -> bool:
+    def almost_equals(self, other, precision: Optional[float] = None) -> bool:
         """Compare transforms for approximate equality.
 
         Parameters

--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -75,7 +75,7 @@ def cos_sin_deg(deg: float):
     return math.cos(rad), math.sin(rad)
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class Affine:
     """Two dimensional affine transform for 2D linear mapping.
 

--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -501,7 +501,7 @@ class Affine:
         """
         return (self.a, self.d), (self.b, self.e), (self.c, self.f)
 
-    def almost_equals(self, other, precision: float = EPSILON) -> bool:
+    def almost_equals(self, other, precision: float = None) -> bool:
         """Compare transforms for approximate equality.
 
         Parameters
@@ -517,16 +517,18 @@ class Affine:
             True if absolute difference between each element
             of each respective transform matrix < ``precision``.
         """
-        for attr in "abcdef":
-            if abs(getattr(self, attr) - getattr(other, attr)) >= precision:
-                return False
-        return True
+        precision = precision or self.precision
+        return all(abs(sv - ov) < precision for sv, ov in zip(self, other))
+
+    @cached_property
+    def _astuple(self):
+        return astuple(self)
 
     def __getitem__(self, index):
-        return astuple(self)[index]
+        return self._astuple[index]
 
     def __iter__(self):
-        return iter(astuple(self))
+        return iter(self._astuple)
 
     def __len__(self):
         return 9

--- a/src/affine/tests/test_transform.py
+++ b/src/affine/tests/test_transform.py
@@ -116,19 +116,19 @@ class PyAffineTestCase(unittest.TestCase):
     def test_identity_constructor(self):
         ident = Affine.identity()
         assert isinstance(ident, Affine)
-        assert tuple(ident) == (1, 0, 0, 0, 1, 0, 0, 0, 1)
+        assert tuple(ident) == (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
         assert ident.is_identity
 
     def test_permutation_constructor(self):
         perm = Affine.permutation()
         assert isinstance(perm, Affine)
-        assert tuple(perm) == (0, 1, 0, 1, 0, 0, 0, 0, 1)
+        assert tuple(perm) == (0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
         assert (perm * perm).is_identity
 
     def test_translation_constructor(self):
         trans = Affine.translation(2, -5)
         assert isinstance(trans, Affine)
-        assert tuple(trans) == (1, 0, 2, 0, 1, -5, 0, 0, 1)
+        assert tuple(trans) == (1.0, 0.0, 2.0, 0.0, 1.0, -5.0, 0.0, 0.0, 1.0)
 
     def test_scale_constructor(self):
         scale = Affine.scale(5)
@@ -448,9 +448,6 @@ def test_rmul_tuple():
 def test_transform_precision():
     t = Affine.rotation(45.0)
     assert t.precision == EPSILON
-    t.precision = 1e-10
-    assert t.precision == 1e-10
-    assert Affine.rotation(0.0).precision == EPSILON
 
 
 def test_associative():


### PR DESCRIPTION
Namedtuple is a bit awkward to use and today people would expect Affine to be a modern data class. I tried to use the stdlib's dataclasses at first, but was blocked by the lack of converters.

Will rebase this once #110 is merge.