### PR TITLE
Special handling of 3x3 arrays with non-default values on bottom row

### DIFF
--- a/affine.py
+++ b/affine.py
@@ -82,27 +82,23 @@ class Affine:
 
     Parameters
     ----------
-    a, b, c, d, e, f : float
-        Coefficients of an augmented affine transformation matrix
-
-        | x' |   | a  b  c | | x |
-        | y' | = | d  e  f | | y |
-        | 1  |   | 0  0  1 | | 1 |
-
+    a, b, c, d, e, f, [g, h, i] : float
+        Coefficients of the 3x3 augmented affine transformation matrix.
         `a`, `b`, and `c` are the elements of the first row of the
         matrix. `d`, `e`, and `f` are the elements of the second row.
+        Defaults for `g`, `h`, and `i` are 0, 0, and 1.
 
     Attributes
     ----------
     a, b, c, d, e, f, g, h, i : float
         The coefficients of the 3x3 augmented affine transformation
-        matrix
+        matrix::
 
-        | x' |   | a  b  c | | x |
-        | y' | = | d  e  f | | y |
-        | 1  |   | g  h  i | | 1 |
+            | x' |   | a  b  c | | x |
+            | y' | = | d  e  f | | y |
+            | 1  |   | g  h  i | | 1 |
 
-        `g`, `h`, and `i` are always 0, 0, and 1.
+        `g`, `h`, and `i` should be 0, 0, and 1.
 
     The Affine package is derived from Casey Duncan's Planar package.
     See the copyright statement below.  Parallel lines are preserved by
@@ -291,7 +287,7 @@ class Affine:
             [
                 [self.a, self.b, self.c],
                 [self.d, self.e, self.f],
-                [0.0, 0.0, 1.0],
+                [self.g, self.h, self.i],
             ],
             dtype=dtype or float,
         )
@@ -306,10 +302,14 @@ class Affine:
 
     def __repr__(self) -> str:
         """Precise string representation."""
-        return (
+        ret = (
             f"Affine({self.a!r}, {self.b!r}, {self.c!r},\n"
-            f"       {self.d!r}, {self.e!r}, {self.f!r})"
+            f"       {self.d!r}, {self.e!r}, {self.f!r}"
         )
+        if self.g != 0.0 or self.h != 0.0 or self.i != 1.0:
+            # only show last row if any are not default values
+            ret += f",\n       {self.g!r}, {self.h!r}, {self.i!r}"
+        return ret + ")"
 
     def to_gdal(self):
         """Return same coefficient order expected by GDAL's SetGeoTransform().
@@ -347,6 +347,8 @@ class Affine:
 
         This value is equal to the area scaling factor when the
         transform is applied to a shape.
+
+        This method assumes that `g`, `h`, and `i` are 0, 0, and 1.
 
         Returns
         -------

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -12,27 +12,29 @@ except ImportError:
 
 
 def test_array():
-    tfm = Affine(*np.linspace(0.1, 0.6, 6))
-    tfm_ar = np.array(tfm)
+    a, b, c, d, e, f = (np.arange(6) + 1) / 10
+    tfm = Affine(a, b, c, d, e, f)
     expected = np.array(
         [
-            [0.1, 0.2, 0.3],
-            [0.4, 0.5, 0.6],
-            [0.0, 0.0, 1.0],
+            [a, b, c],
+            [d, e, f],
+            [0, 0, 1],
         ],
     )
-    assert tfm_ar.shape == (3, 3)
-    assert tfm_ar.dtype == np.float64
-    testing.assert_allclose(tfm_ar, expected)
+    ar = np.array(tfm)
+    assert ar.shape == (3, 3)
+    assert ar.dtype == np.float64
+    testing.assert_allclose(ar, expected)
 
     # dtype option
-    tfm_ar = np.array(tfm, dtype=np.float32)
-    assert tfm_ar.shape == (3, 3)
-    assert tfm_ar.dtype == np.float32
-    testing.assert_allclose(tfm_ar, expected)
+    ar = np.array(tfm, dtype=np.float32)
+    assert ar.shape == (3, 3)
+    assert ar.dtype == np.float32
+    testing.assert_allclose(ar, expected)
 
     # copy option
-    tfm_ar = np.array(tfm, copy=True)  # default None does the same
+    ar = np.array(tfm, copy=True)  # default None does the same
+    testing.assert_allclose(ar, expected)
 
     # Behaviour of copy=False is different between NumPy 1.x and 2.x
     if int(np.version.short_version.split(".", 1)[0]) >= 2:
@@ -40,3 +42,46 @@ def test_array():
             np.array(tfm, copy=False)
     else:
         testing.assert_allclose(np.array(tfm, copy=False), expected)
+
+    # cross-check some properties
+    ar = np.array(tfm)
+    assert tfm.determinant == pytest.approx(np.linalg.det(ar))
+    np.testing.assert_allclose(~tfm, np.linalg.inv(ar))
+
+    # check 3x3 array, with unexpected g, h, i values
+    a, b, c, d, e, f, g, h, i = [7, 2, 1, 0, 3, -1, -3, 4, -2]
+    tfm = Affine(a, b, c, d, e, f, g, h, i)
+    ar = np.array(tfm)
+    assert ar.shape == (3, 3)
+    assert ar.dtype == np.float64
+    testing.assert_array_equal(
+        ar,
+        [
+            [a, b, c],
+            [d, e, f],
+            [g, h, i],
+        ],
+    )
+
+    # only numpy can calculate 3x3 answers
+    assert np.linalg.det(ar) == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        [
+            [-2.0, 8.0, -5.0],
+            [3.0, -11.0, 7.0],
+            [9.0, -34.0, 21.0],
+        ],
+        np.linalg.inv(ar),
+    )
+
+    # Affine's properties assume 2x2 arrays
+    # thus have different answers than numpy
+    ar2x2 = np.array(
+        [
+            [a, b, c],
+            [d, e, f],
+            [0, 0, 1],
+        ],
+    )
+    assert tfm.determinant == pytest.approx(np.linalg.det(ar2x2))
+    np.testing.assert_allclose(~tfm, np.linalg.inv(ar2x2))

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -9,8 +9,11 @@ import affine
 
 
 def test_pickle():
-    a = affine.Affine(1, 2, 3, 4, 5, 6)
-    assert pickle.loads(pickle.dumps(a)) == a
+    a1 = affine.Affine(1, 2, 3, 4, 5, 6)
+    assert pickle.loads(pickle.dumps(a1)) == a1
+    # specify different g, h, i values than defaults
+    a2 = affine.Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert pickle.loads(pickle.dumps(a2)) == a2
 
 
 def _mp_proc(x):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -77,6 +77,39 @@ def test_slice_last_row():
     t = Affine(1, 2, 3, 4, 5, 6)
     assert t[-3:] == (0, 0, 1)
 
+    # abnormal use, since g, h, i are normally 0, 0, and 1
+    t = Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert t[-3:] == (7, 8, 9)
+
+
+def test_members():
+    t = Affine(1, 2, 3, 4, 5, 6)
+    assert t.a == 1
+    assert t.b == 2
+    assert t.c == 3
+    assert t.d == 4
+    assert t.e == 5
+    assert t.f == 6
+    assert t.g == 0
+    assert t.h == 0
+    assert t.i == 1
+    assert t.c is t.xoff
+    assert t.f is t.yoff
+
+    # abnormal use, since g, h, i are normally 0, 0, and 1
+    t = Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert t.a == 1
+    assert t.b == 2
+    assert t.c == 3
+    assert t.d == 4
+    assert t.e == 5
+    assert t.f == 6
+    assert t.g == 7
+    assert t.h == 8
+    assert t.i == 9
+    assert t.c is t.xoff
+    assert t.f is t.yoff
+
 
 def test_members_are_floats():
     t = Affine(1, 2, 3, 4, 5, 6)
@@ -97,6 +130,19 @@ def test_getitem():
     assert t[8] == 1
     assert t[-1] == 1
 
+    # abnormal use, since g, h, i are normally 0, 0, and 1
+    t = Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert t[0] == 1
+    assert t[1] == 2
+    assert t[2] == 3
+    assert t[3] == 4
+    assert t[4] == 5
+    assert t[5] == 6
+    assert t[6] == 7
+    assert t[7] == 8
+    assert t[8] == 9
+    assert t[-1] == 9
+
 
 def test_getitem_wrong_type():
     t = Affine(1, 2, 3, 4, 5, 6)
@@ -113,6 +159,15 @@ def test_str():
         | 0.00, 0.00, 1.00|"""
     )
 
+    # abnormal use, since g, h, i are normally 0, 0, and 1
+    t = Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert str(t) == dedent(
+        """\
+        | 1.00, 2.00, 3.00|
+        | 4.00, 5.00, 6.00|
+        | 7.00, 8.00, 9.00|"""
+    )
+
 
 def test_repr():
     t = Affine(1.111, 2.222, 3.456, 4.444, 5.5, 6.25)
@@ -120,6 +175,22 @@ def test_repr():
         """\
         Affine(1.111, 2.222, 3.456,
                4.444, 5.5, 6.25)"""
+    )
+
+    # abnormal use, since g, h, i are normally 0, 0, and 1
+    t = Affine(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert repr(t) == dedent(
+        """\
+        Affine(1.0, 2.0, 3.0,
+               4.0, 5.0, 6.0,
+               7.0, 8.0, 9.0)"""
+    )
+    t = Affine(1.111, 2.222, 3.456, 4.444, 5.5, 6.25, i=0.001)
+    assert repr(t) == dedent(
+        """\
+        Affine(1.111, 2.222, 3.456,
+               4.444, 5.5, 6.25,
+               0.0, 0.0, 0.001)"""
     )
 
 


### PR DESCRIPTION
This PR considers that Affine uses 3x3 arrays, where the bottom row is _normally_ [0 0 1], however the API has always permitted other values for the bottom row. This is considered abnormal use for 2D affine transformations, since this should always be [0 0 1]. More background [here](https://people.computing.clemson.edu/~dhouse/courses/401/notes/affines-matrices.pdf) describes the purpose of the last row:
> By convention, we call this third coordinate the _w_ coordinate, to distinguish it from the usual 3D _z_ coordinate.

So it's a 3x3 matrix to handle 2D affine transformations using a _w_ coordinate to accommodate linear algebra methods.

---

Here are the changes to consider abnormal 3x3 arrays:
- Change the NumPy `__array__` interface to pass the whole 3x3 array.
- Change `__repr__` to show the bottom row if any of the values are non default. This allows round-tripping via `eval(repr(t))` to preserve the bottom row values.
- Document that `determinant` assumes that `g`, `h`, and `i` are 0, 0, and 1. The alternative (that I don't recommend) is to implement a typical 3x3 determinant calculation via: _aei + bfg + cdh - ceg - bdi - afh_.
- Add some cross-checks of determinant and matrix inverse with NumPy's [linear algebra](https://numpy.org/doc/stable/reference/routines.linalg.html) methods