### PR TITLE
Raise ValueError if (g, h, i) != (0.0, 0.0, 1.0)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,13 +5,12 @@ CHANGES
 -----------
 
 - Affine raises ValueError if initialized with values for g, h, and i that are
-  not 0.0, 0.0, and 1.0, respectively (#118).
+  not 0.0, 0.0, and 1.0, respectively (#117).
 - Python version support was changed to 3.9+ (#110).
 - Switch from namedtuple to attrs for implementation of the Affine class and
   use functools.cached_property(), which absolutely requires Python 3.8+
   (#111).
-- Source was moved to a single-module affine.py in the src directory (#112,
-  #117).
+- Source was moved to a single-module affine.py in the src directory (#112).
 - Add numpy __array__ interface (#108).
 
 2.4.0 (2023-01-19)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ CHANGES
 3.0a1 (TBD)
 -----------
 
+- Affine raises ValueError if initialized with values for g, h, and i that are
+  not 0.0, 0.0, and 1.0, respectively (#118).
 - Python version support was changed to 3.9+ (#110).
 - Switch from namedtuple to attrs for implementation of the Affine class and
   use functools.cached_property(), which absolutely requires Python 3.8+

--- a/src/affine.py
+++ b/src/affine.py
@@ -131,9 +131,29 @@ class Affine:
     d: float = field(converter=float)
     e: float = field(converter=float)
     f: float = field(converter=float)
+
+    # The class has 3 attributes that don't have to be specified: g, h,
+    # and i. If they are, the given value has to be the same as the
+    # default value. This allows a new instances to be created from the
+    # tuple form of another, like Affine(*Affine.identity()).
+
     g: float = field(default=0.0, converter=float)
+    @g.validator
+    def _check_g(self, attribute, value):
+        if value != 0.0:
+            raise ValueError("g must be equal to 0.0")
+
     h: float = field(default=0.0, converter=float)
+    @h.validator
+    def _check_h(self, attribute, value):
+        if value != 0.0:
+            raise ValueError("h must be equal to 0.0")
+
     i: float = field(default=1.0, converter=float)
+    @i.validator
+    def _check_i(self, attribute, value):
+        if value != 1.0:
+            raise ValueError("i must be equal to 1.0")
 
     @classmethod
     def from_gdal(cls, c: float, a: float, b: float, f: float, d: float, e: float):

--- a/src/affine.py
+++ b/src/affine.py
@@ -138,18 +138,21 @@ class Affine:
     # tuple form of another, like Affine(*Affine.identity()).
 
     g: float = field(default=0.0, converter=float)
+
     @g.validator
     def _check_g(self, attribute, value):
         if value != 0.0:
             raise ValueError("g must be equal to 0.0")
 
     h: float = field(default=0.0, converter=float)
+
     @h.validator
     def _check_h(self, attribute, value):
         if value != 0.0:
             raise ValueError("h must be equal to 0.0")
 
     i: float = field(default=1.0, converter=float)
+
     @i.validator
     def _check_i(self, attribute, value):
         if value != 1.0:

--- a/src/affine.py
+++ b/src/affine.py
@@ -82,8 +82,8 @@ class Affine:
 
     Parameters
     ----------
-    a, b, c, d, e, f : float
-        Coefficients of an augmented affine transformation matrix
+    a, b, c, d, e, f, [g, h, i] : float
+        Coefficients of the 3 x 3 augmented affine transformation matrix.
 
         | x' |   | a  b  c | | x |
         | y' | = | d  e  f | | y |
@@ -95,12 +95,12 @@ class Affine:
     Attributes
     ----------
     a, b, c, d, e, f, g, h, i : float
-        The coefficients of the 3x3 augmented affine transformation
-        matrix
+        The coefficients of the 3 x 3 augmented affine transformation
+        matrix::
 
-        | x' |   | a  b  c | | x |
-        | y' | = | d  e  f | | y |
-        | 1  |   | g  h  i | | 1 |
+            | x' |   | a  b  c | | x |
+            | y' | = | d  e  f | | y |
+            | 1  |   | g  h  i | | 1 |
 
         `g`, `h`, and `i` are always 0, 0, and 1.
 
@@ -310,14 +310,7 @@ class Affine:
 
         if copy is False:
             raise ValueError("`copy=False` isn't supported. A copy is always created.")
-        return np.array(
-            [
-                [self.a, self.b, self.c],
-                [self.d, self.e, self.f],
-                [0.0, 0.0, 1.0],
-            ],
-            dtype=dtype or float,
-        )
+        return np.array(self._astuple, dtype=(dtype or float)).reshape((3, 3))
 
     def __str__(self) -> str:
         """Concise string representation."""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -564,3 +564,18 @@ def test_mul_fallback_type_error():
             return other * (1, 2)
 
     assert Affine.identity() * TextPoint() == (1, 2)
+
+
+def test_init_invalid_g():
+    with pytest.raises(ValueError, match="g must"):
+        Affine(0, 0, 0, 0, 0, 0, 1)
+
+
+def test_init_invalid_h():
+    with pytest.raises(ValueError, match="h must"):
+        Affine(0, 0, 0, 0, 0, 0, 0, 1)
+
+
+def test_init_invalid_i():
+    with pytest.raises(ValueError, match="i must"):
+        Affine(0, 0, 0, 0, 0, 0, 0, 0, 0)


### PR DESCRIPTION
These are optional attributes with default values. If given, the values *must* be the same as the attribute defaults.

This allows a new instances to be created from the tuple form of another, like `Affine(*Affine.identity())`. But does not allow a user to create a non-affine matrix.

@mwtoews I think this is the attrs way to do it.
