### PR TITLE
Validate bottom row [g, h, i] to always be [0, 0, 1]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ CHANGES
 - Source was moved to a single-module affine.py in the src directory (#112,
   #117).
 - Add numpy __array__ interface (#108).
+- Validate bottom row [g, h, i] to always be [0, 0, 1] (#118)
 
 2.4.0 (2023-01-19)
 ------------------

--- a/src/affine.py
+++ b/src/affine.py
@@ -76,31 +76,37 @@ def cos_sin_deg(deg: float):
     return math.cos(rad), math.sin(rad)
 
 
+def validate_zero(instance, attribute, value):
+    if value != 0.0:
+        raise ValueError(f"{attribute.name} must be 0.0; found {value}")
+
+
+def validate_one(instance, attribute, value):
+    if value != 1.0:
+        raise ValueError(f"{attribute.name} must be 1.0; found {value}")
+
+
 @define(frozen=True)
 class Affine:
     """Two dimensional affine transform for 2D linear mapping.
 
     Parameters
     ----------
-    a, b, c, d, e, f : float
-        Coefficients of an augmented affine transformation matrix
-
-        | x' |   | a  b  c | | x |
-        | y' | = | d  e  f | | y |
-        | 1  |   | 0  0  1 | | 1 |
-
+    a, b, c, d, e, f, [g, h, i] : float
+        Coefficients of the 3x3 augmented affine transformation matrix.
         `a`, `b`, and `c` are the elements of the first row of the
         matrix. `d`, `e`, and `f` are the elements of the second row.
+        Defaults for `g`, `h`, and `i` are 0, 0, and 1.
 
     Attributes
     ----------
     a, b, c, d, e, f, g, h, i : float
         The coefficients of the 3x3 augmented affine transformation
-        matrix
+        matrix::
 
-        | x' |   | a  b  c | | x |
-        | y' | = | d  e  f | | y |
-        | 1  |   | g  h  i | | 1 |
+            | x' |   | a  b  c | | x |
+            | y' | = | d  e  f | | y |
+            | 1  |   | g  h  i | | 1 |
 
         `g`, `h`, and `i` are always 0, 0, and 1.
 
@@ -131,9 +137,9 @@ class Affine:
     d: float = field(converter=float)
     e: float = field(converter=float)
     f: float = field(converter=float)
-    g: float = field(default=0.0, converter=float)
-    h: float = field(default=0.0, converter=float)
-    i: float = field(default=1.0, converter=float)
+    g: float = field(default=0.0, converter=float, validator=validate_zero)
+    h: float = field(default=0.0, converter=float, validator=validate_zero)
+    i: float = field(default=1.0, converter=float, validator=validate_one)
 
     @classmethod
     def from_gdal(cls, c: float, a: float, b: float, f: float, d: float, e: float):
@@ -291,7 +297,7 @@ class Affine:
             [
                 [self.a, self.b, self.c],
                 [self.d, self.e, self.f],
-                [0.0, 0.0, 1.0],
+                [self.g, self.h, self.i],
             ],
             dtype=dtype or float,
         )
@@ -347,6 +353,8 @@ class Affine:
 
         This value is equal to the area scaling factor when the
         transform is applied to a shape.
+
+        This method assumes that `g`, `h`, and `i` are 0, 0, and 1.
 
         Returns
         -------

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -68,6 +68,15 @@ def test_args_members_wrong_type():
         Affine(0, 2, 3, None, None, "")
 
 
+def test_args_wrong_value():
+    with pytest.raises(ValueError, match="g must be 0.0; found 7.0"):
+        Affine(1, 2, 3, 4, 5, 6, 7)
+    with pytest.raises(ValueError, match="h must be 0.0; found 8.0"):
+        Affine(1, 2, 3, 4, 5, 6, h=8)
+    with pytest.raises(ValueError, match="i must be 1.0; found 9.0"):
+        Affine(1, 2, 3, 4, 5, 6, i=9)
+
+
 def test_len():
     t = Affine(1, 2, 3, 4, 5, 6)
     assert len(t) == 9
@@ -76,6 +85,21 @@ def test_len():
 def test_slice_last_row():
     t = Affine(1, 2, 3, 4, 5, 6)
     assert t[-3:] == (0, 0, 1)
+
+
+def test_members():
+    t = Affine(1, 2, 3, 4, 5, 6)
+    assert t.a == 1
+    assert t.b == 2
+    assert t.c == 3
+    assert t.d == 4
+    assert t.e == 5
+    assert t.f == 6
+    assert t.g == 0
+    assert t.h == 0
+    assert t.i == 1
+    assert t.c is t.xoff
+    assert t.f is t.yoff
 
 
 def test_members_are_floats():


### PR DESCRIPTION
This validation will add a bit of overhead, but will always ensure that the bottom row is [0, 0, 1].