### PR TITLE
Misc: more lints, tests and minor fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Matrices describing 2D affine transformation of the plane.
        :alt: Documentation Status
 
 The Affine package is derived from Casey Duncan's Planar package. Please see
-the copyright statement in `affine.py <affine.py>`__.
+the copyright statement in `src/affine.py <src/affine.py>`__.
 
 Usage
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ include = [
     "tests/",
 ]
 
+[tool.pytest.ini_options]
+pythonpath = "src"
+testpaths = ["tests"]
+
 [tool.ruff.lint]
 select = [
     "B",  # flake8-bugbear
@@ -56,7 +60,9 @@ select = [
     "I",  # isort
     "NPY", # NumPy-specific rules
     "PT", # flake8-pytest-style
+    "RET", # flake8-return
     "RUF", # Ruff-specific rules
+    "SIM", # flake8-simplify
     "UP", # pyupgrade
 ]
 ignore = [

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -12,27 +12,29 @@ except ImportError:
 
 
 def test_array():
-    tfm = Affine(*np.linspace(0.1, 0.6, 6))
-    tfm_ar = np.array(tfm)
+    a, b, c, d, e, f = (np.arange(6) + 1) / 10
+    tfm = Affine(a, b, c, d, e, f)
     expected = np.array(
         [
-            [0.1, 0.2, 0.3],
-            [0.4, 0.5, 0.6],
-            [0.0, 0.0, 1.0],
+            [a, b, c],
+            [d, e, f],
+            [0, 0, 1],
         ],
     )
-    assert tfm_ar.shape == (3, 3)
-    assert tfm_ar.dtype == np.float64
-    testing.assert_allclose(tfm_ar, expected)
+    ar = np.array(tfm)
+    assert ar.shape == (3, 3)
+    assert ar.dtype == np.float64
+    testing.assert_array_equal(ar, expected)
 
     # dtype option
-    tfm_ar = np.array(tfm, dtype=np.float32)
-    assert tfm_ar.shape == (3, 3)
-    assert tfm_ar.dtype == np.float32
-    testing.assert_allclose(tfm_ar, expected)
+    ar = np.array(tfm, dtype=np.float32)
+    assert ar.shape == (3, 3)
+    assert ar.dtype == np.float32
+    testing.assert_allclose(ar, expected)
 
     # copy option
-    tfm_ar = np.array(tfm, copy=True)  # default None does the same
+    ar = np.array(tfm, copy=True)  # default None does the same
+    testing.assert_allclose(ar, expected)
 
     # Behaviour of copy=False is different between NumPy 1.x and 2.x
     if int(np.version.short_version.split(".", 1)[0]) >= 2:
@@ -40,3 +42,27 @@ def test_array():
             np.array(tfm, copy=False)
     else:
         testing.assert_allclose(np.array(tfm, copy=False), expected)
+
+
+def test_linalg():
+    # cross-check properties with numpy's linear algebra module
+    ar = np.array(
+        [
+            [0, -2, 2],
+            [3, 0, 5],
+            [0, 0, 1],
+        ]
+    )
+    tfm = Affine(*ar.flatten())
+    assert tfm.determinant == pytest.approx(6.0)
+    assert np.linalg.det(ar) == pytest.approx(6.0)
+
+    expected_inv = np.array(
+        [
+            [0, 1 / 3, -5 / 3],
+            [-1 / 2, 0, 1],
+            [0, 0, 1],
+        ]
+    )
+    testing.assert_allclose(~tfm, expected_inv)
+    testing.assert_allclose(np.linalg.inv(ar), expected_inv)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -78,6 +78,22 @@ def test_slice_last_row():
     assert t[-3:] == (0, 0, 1)
 
 
+def test_members():
+    t = Affine(1, 2, 3, 4, 5, 6)
+    assert t.a == 1
+    assert t.b == 2
+    assert t.c == 3
+    assert t.d == 4
+    assert t.e == 5
+    assert t.f == 6
+    assert t.g == 0
+    assert t.h == 0
+    assert t.i == 1
+    # these are aliases
+    assert t.c is t.xoff
+    assert t.f is t.yoff
+
+
 def test_members_are_floats():
     t = Affine(1, 2, 3, 4, 5, 6)
     for m in t:
@@ -463,15 +479,13 @@ def test_shapely():
 
 def test_imul_number():
     t = Affine(1, 2, 3, 4, 5, 6)
-    try:
+    with pytest.raises(TypeError):
         t *= 2.0
-    except TypeError:
-        assert True
 
 
 def test_mul_tuple():
     t = Affine(1, 2, 3, 4, 5, 6)
-    t * (2.0, 2.0)
+    assert t * (2, 2) == (9, 24)
 
 
 def test_rmul_tuple():


### PR DESCRIPTION
This is a miscellaneous collection of minor changes.

- Add a few more Ruff check rules, with associated changes
- Fix link to main source file referenced in README.rst
- Specify pytest configuration, most importantly set pythonpath to src (this allows `pytest` to work without installing the package)
- Add some NumPy linear algebra module cross-check tests
- Add test to check members `a`, `b`, etc., as this seems missing