### PR TITLE
Fix path to build module documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+attrs
 sphinx==6.2.1

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -5,13 +5,13 @@
 import os
 import sys
 
-sys.path.append(os.path.abspath("../.."))
+sys.path.append(os.path.abspath("../../src"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "rasterio/affine"
-copyright = "2023, Sean Gillies"
+copyright = "2025, Sean Gillies"
 author = "Sean Gillies"
 release = "development"
 


### PR DESCRIPTION
This should fix RTD to build the module documentation, which currently is a blank section.