### PR TITLE
Implement typing overloads for (matrix) multiplication

### DIFF
--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -37,13 +37,10 @@ from __future__ import annotations
 from collections.abc import MutableSequence, Sequence
 from functools import cached_property
 import math
-from typing import TYPE_CHECKING
+from typing import overload
 import warnings
 
 from attrs import astuple, define, field
-
-if TYPE_CHECKING:
-    from typing import overload
 
 __all__ = ["Affine"]
 __author__ = "Sean Gillies"
@@ -620,7 +617,7 @@ class Affine:
     def __rmatmul__(self, other):
         return NotImplemented
 
-    def __imatmul__(self, other):
+    def __imatmul__(self, other):  # type: ignore
         if not isinstance(other, Affine):
             raise TypeError("Operation not supported")
         return NotImplemented
@@ -661,7 +658,7 @@ class Affine:
     def __rmul__(self, other):
         return NotImplemented
 
-    def __imul__(self, other):
+    def __imul__(self, other):  # type: ignore
         if isinstance(other, tuple):
             warnings.warn(
                 "in-place multiplication with tuple is deprecated",


### PR DESCRIPTION
Currently when performing multiplication and matrix multiplication, there is poor type hinting.  Currently types are resolved as 
```
Affine | NotImplementedType | tuple[Unknown, Unknown] | tuple[Unknown, Unknown, Unbound | Unknown] | Unknown
```

<img width="658" height="239" alt="image" src="https://github.com/user-attachments/assets/8bd9596b-c1f6-4e59-95cc-a935ac010eb7" />

(the gray text is _inlay hints_, meaning those are the inferred types that the editor is showing)

With additional errors of:
```
Operator "*" not supported for types "Affine | NotImplementedType | tuple[Unknown, Unknown] | tuple[Unknown, Unknown, Unbound | Unknown]" and "tuple[Literal[5], Literal[6]]"
  Operator "*" not supported for types "tuple[Unknown, Unknown]" and "tuple[Literal[5], Literal[6]]"
  Operator "*" not supported for types "tuple[Unknown, Unknown, Unbound | Unknown]" and "tuple[Literal[5], Literal[6]]"Pylance[reportOperatorIssue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOperatorIssue.md)
```

----

After this PR, types are inferred cleanly:

<img width="550" height="251" alt="image" src="https://github.com/user-attachments/assets/8d595392-0609-4882-a568-5526ca76843b" />

Happy to create tests for these if the PR sounds good and you want them. We could use https://github.com/davidfritzsche/pytest-mypy-testing