### PR TITLE
Improved typing for `__array__`

### DIFF
--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -37,18 +37,14 @@ from __future__ import annotations
 from collections.abc import MutableSequence, Sequence
 from functools import cached_property
 import math
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING
 import warnings
 
 from attrs import astuple, define, field
 
 if TYPE_CHECKING:
-    from typing import TypeVar, overload
-
     import numpy as np
     from numpy.typing import NDArray
-
-    _ScalarType = TypeVar("_ScalarType", bound=np.generic)
 
 
 __all__ = ["Affine"]


### PR DESCRIPTION
Similar in spirit to #137 for for the `__array__` conversion to numpy.

This one is **less important** than #137 so it's ok if you reject it for complexity:

Before:

<img width="667" height="157" alt="image" src="https://github.com/user-attachments/assets/600831f5-0e98-4a5e-990e-45c5487d3535" />


After:

<img width="663" height="160" alt="image" src="https://github.com/user-attachments/assets/a82be55c-8205-41b9-8508-cf34a557d847" />

- This effectively just changes the behavior of `np.asarray` when no explicit `dtype` is provided (assuming users call `np.asarray` and not `Affine.__array__`)
- I like to have "complete" typing like this, but compared to #137 it's not as crucial to have the type checker know that the array is a `float64` array specifically.