### PR TITLE
feat: move dev dependencies according to PEP 735

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pre-commit
+          python -m pip install . --group dev
           pre-commit run --show-diff-on-failure --all-files
 
   tests:
@@ -42,7 +42,7 @@ jobs:
       - name: Install affine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .["test"]
+          python -m pip install . --group test
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install affine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install . --group test
+          python -m pip install . --group tests
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pre-commit
+          python -m pip install --group dev
           pre-commit run --show-diff-on-failure --all-files
 
   tests:
@@ -42,7 +42,7 @@ jobs:
       - name: Install affine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .["test"]
+          python -m pip install . --group tests
 
       - name: Run tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.22
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -16,7 +16,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.3.0
     hooks:
       - id: mypy
         additional_dependencies: [attrs]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.16.3
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -16,7 +16,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.3.0
     hooks:
       - id: mypy
         additional_dependencies: [attrs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,17 @@ dependencies = [
     "attrs",
 ]
 
-[project.optional-dependencies]
-test = [
+[dependency-groups]
+dev = [
+    "coveralls>=3.0",
+    "pre-commit>=4.3.0",
+    "tox>=4.22",
+    {include-group = "tests"},
+]
+tests = [
     "numpy>=1.20",
     "pytest>=6.0",
     "pytest-cov",
-]
-dev = [
-    "coveralls>=3.0",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     py39,py310,py311,py312,py313,py314
+requires =
+    tox>4.22
 
 [testenv]
 usedevelop = true
-deps =
-    numpy
-    pytest-cov
+dependency_groups = tests
 commands =
     python -m pytest  --cov affine --cov-report term-missing


### PR DESCRIPTION
Move dev dependencies according to PEP 735 into `[dependency-groups]`.
Move more dependencies to `pyproject.toml`