### PR TITLE
Improve license metadata (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -13,14 +13,14 @@ readme = "README.rst"
 keywords = ["affine", "transformation", "matrix"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Multimedia :: Graphics :: Graphics Conversion",
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["AUTHORS.txt", "LICENSE.txt"]
 requires-python = ">=3.9"
 dependencies = [
     "attrs",


### PR DESCRIPTION
This improves the licence metadata, following [PEP 639](https://peps.python.org/pep-0639/) with the following changes:
- Feature requires flit [v3.11](https://flit.pypa.io/en/stable/history.html#version-3-11)
- Change `license` from a deprecated table structure to a simpler text field with a valid SPDX licence identifier
- Specify the "licence" files, which includes AUTHORS.txt
- Remove deprecated licence classifier