### PR TITLE
Raise PendingDeprecationWarning for `*` mul operator for matrix multiplaction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,21 +52,26 @@ Matrices can be created by passing the values ``a, b, c, d, e, f`` to the
          0.7071067811865475, 0.7071067811865476, 0.0)
 
 These matrices can be applied to ``(x, y)`` tuples using the
-``*`` operator (or the ``@`` matrix multiplier operator for
-future releases) to obtain transformed coordinates ``(x', y')``.
+``@`` matrix multiplier operator to obtain transformed
+coordinates ``(x', y')``.
 
 .. code-block:: pycon
 
-  >>> Affine.translation(1.0, 5.0) * (1.0, 1.0)
+  >>> Affine.translation(1.0, 5.0) @ (1.0, 1.0)
   (2.0, 6.0)
-  >>> Affine.rotation(45.0) * (1.0, 1.0)
+  >>> Affine.rotation(45.0) @ (1.0, 1.0)
   (1.1102230246251565e-16, 1.414213562373095)
+
+.. note::
+   Versions before 3.0.0 only supported the ``*`` operator for
+   matrix multiplication. To use these examples with previous
+   releases, replace ``@`` with ``*``.
 
 They may also be multiplied together to combine transformations.
 
 .. code-block:: pycon
 
-  >>> Affine.translation(1.0, 5.0) * Affine.rotation(45.0)
+  >>> Affine.translation(1.0, 5.0) @ Affine.rotation(45.0)
   Affine(0.7071067811865476, -0.7071067811865475, 1.0,
          0.7071067811865475, 0.7071067811865476, 5.0)
 
@@ -89,7 +94,7 @@ origin can be easily computed.
   >>> geotransform = (-237481.5, 425.0, 0.0, 237536.4, 0.0, -425.0)
   >>> fwd = Affine.from_gdal(*geotransform)
   >>> col, row = 0, 100
-  >>> fwd * (col, row)
+  >>> fwd @ (col, row)
   (-237481.5, 195036.4)
 
 The reverse transformation is obtained using the ``~`` inverse operator.
@@ -97,5 +102,5 @@ The reverse transformation is obtained using the ``~`` inverse operator.
 .. code-block:: pycon
 
   >>> rev = ~fwd
-  >>> rev * fwd * (col, row)
+  >>> rev @ fwd @ (col, row)
   (0.0, 99.99999999999999)

--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -615,13 +615,15 @@ class Affine:
         Returns
         -------
         Affine or a tuple of two items
+
+        .. deprecated:: 3.1.0
+            Use `@` matmul instead of `*` mul operator for matrix multiplication.
         """
-        # TODO: consider enabling this for 3.1
-        # warnings.warn(
-        #     "Use `@` matmul instead of `*` mul operator for matrix multiplication",
-        #     PendingDeprecationWarning,
-        #     stacklevel=2,
-        # )
+        warnings.warn(
+            "Use `@` matmul instead of `*` mul operator for matrix multiplication",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(other, Affine):
             return self.__matmul__(other)
         try:

--- a/src/affine/__init__.py
+++ b/src/affine/__init__.py
@@ -619,6 +619,7 @@ class Affine:
         .. deprecated:: 3.1.0
             Use `@` matmul instead of `*` mul operator for matrix multiplication.
         """
+        # TODO: consider elevating to DeprecationWarning for 3.2
         warnings.warn(
             "Use `@` matmul instead of `*` mul operator for matrix multiplication",
             PendingDeprecationWarning,

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -107,7 +107,8 @@ def test_matmul_items():
     testing.assert_array_equal(pw, np.ones(shape))
 
     # see GH-125 with mul `*` op
-    px, py = A * (vx, vy)
+    with pytest.deprecated_call():
+        px, py = A * (vx, vy)
     testing.assert_allclose(px, expected_px)
     testing.assert_allclose(py, expected_py)
 
@@ -126,7 +127,7 @@ def test_matmul_item_errors():
 def test_mul_item_errors():
     shape = (4, 5)
     vx, vy = np.meshgrid(np.arange(shape[1]), np.arange(shape[0]))
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), pytest.deprecated_call():
         Affine.identity() * (vx, vy, 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), pytest.deprecated_call():
         Affine.identity() * (vx, vy, np.zeros(shape))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -376,7 +376,7 @@ def test_itransform():
 
 
 def test_mul_wrong_type():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), pytest.deprecated_call():
         Affine(1, 2, 3, 4, 5, 6) * None
 
 
@@ -394,7 +394,7 @@ def test_matmul_sequence_wrong_member_types():
         def __iter__():
             yield 0
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), pytest.deprecated_call():
         Affine(1, 2, 3, 4, 5, 6) * NotPtSeq()
 
     with pytest.raises(TypeError):
@@ -403,7 +403,7 @@ def test_matmul_sequence_wrong_member_types():
 
 def test_imul_errors():
     t = Affine.identity()
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), pytest.deprecated_call():
         t *= 2.0
 
 
@@ -427,7 +427,8 @@ def test_imul_tuple():
 
 def test_imul_transform():
     t = Affine.translation(3, 5)
-    t *= Affine.translation(-2, 3.5)
+    with pytest.deprecated_call():
+        t *= Affine.translation(-2, 3.5)
     assert isinstance(t, Affine)
     seq_almost_equal(t, Affine.translation(1, 8.5))
 
@@ -532,8 +533,9 @@ def test_rmatmul_errors():
 
 def test_mul_tuple():
     t = Affine(1, 2, 3, 4, 5, 6)
-    assert t * (2, 2) == (9, 24)
-    with pytest.raises(TypeError):
+    with pytest.deprecated_call():
+        assert t * (2, 2) == (9, 24)
+    with pytest.raises(TypeError), pytest.deprecated_call():
         t * (2, 2, 1)
 
 
@@ -607,7 +609,8 @@ def test_mul_fallback_unpack():
         def __rmatmul__(self, other):
             return other @ (1, 2)
 
-    assert Affine.identity() * TextPoint() == (1, 2)
+    with pytest.deprecated_call():
+        assert Affine.identity() * TextPoint() == (1, 2)
 
     assert Affine.identity() @ TextPoint() == (1, 2)
 
@@ -628,7 +631,8 @@ def test_mul_fallback_type_error():
         def __rmatmul__(self, other):
             return other @ (1, 2)
 
-    assert Affine.identity() * TextPoint() == (1, 2)
+    with pytest.deprecated_call():
+        assert Affine.identity() * TextPoint() == (1, 2)
     assert Affine.identity() @ TextPoint() == (1, 2)
 
 


### PR DESCRIPTION
Affine 3.0.0 introduced the `@`/`__matmul__` matrix multiplication method (#122).

This PR now raises PendingDeprecationWarning when using the now older `*` operator, intended for developers to see.

It can be a DeprecationWarning for a future release, which is intended for users to see.

Also, finally update README.rst with examples that use `@` instead of `*` for matrix multiplication. This can be manually verified with `python -Wall -m doctest README.rst`.

---

### Advice for developers

Take this example:
```python
from affine import Affine

translation = Affine.translation(10, 20)
rotation = Affine.rotation(30)
scale = Affine.scale(2, 3)
transform = translation * scale * rotation
```
Assume users have a mixture of versions before/after 3.0.0, so refactor the matrix multiplication like this:
```python
try:  # affine>=3.0.0
    transform = translation @ scale @ rotation
except TypeError:  # affine<3.0.0
    transform = translation * scale * rotation
```
and yes, this will replace 1-line of code with 4 lines, but it will handle the warning.

Alternately, for a "helper" function that can be declared once and used for single-line refactors, try this:
```python
from functools import reduce

def matmul(*items):
    """Try matmul on items before falling back to mul operator."""
    try:
        return reduce(lambda a, b: a @ b, items)
    except TypeError:
        return reduce(lambda a, b: a * b, items)

transform = matmul(translation, scale, rotation)
```
And be aware that the order of matrix multiplication matters, and this helper function preserves the correct order as expected.