### PR TITLE
Add minimal verison for attrs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = "BSD-3-Clause"
 license-files = ["AUTHORS.txt", "LICENSE.txt"]
 requires-python = ">=3.9"
 dependencies = [
-    "attrs",
+    "attrs>=21.3.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Solve issue #147. attrs dependency was included by commit 4311b82e6ac7aefc32414de0dfe2a1fe038b35a4 with an import on the form of import attrs. However, this import is only valid for versions of attrs after 21.3.0 as the import was done with import attr in previous verions. this minimal version is therefore required to be able to import the affine code.